### PR TITLE
Add same font-family on synopsis as on code

### DIFF
--- a/assets/sass/typography.scss
+++ b/assets/sass/typography.scss
@@ -265,6 +265,7 @@ code {
 p {
     .synopsis {
 	@include border-radius(3px);
+	font-family: $fixed-width-font-family;
 	border: solid 1px var(--pre-border);
     }
 }


### PR DESCRIPTION
## Changes

- add 'font-family' to synopsis class that is same as for 'code' elements

## Context

This makes sure that spaces inserted between 'code' elements have the same size as text inside of 'code' elements, otherwise spaces look tiny and words in commands such as 'git merge' visually look almost touching each other.

Before: 
![image](https://github.com/user-attachments/assets/c820a83f-eafd-4a92-bc30-fa26f3b89d0f)

After:
![image](https://github.com/user-attachments/assets/6a9b3be4-ec18-4bbd-b5b3-5b7b4bd036d8)


